### PR TITLE
chglog config was pointing to etherpad repo

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/owncloud-ops/etherpad
+  repository_url: https://github.com/owncloud-ops/gitea
 options:
   commit_groups:
     title_maps:


### PR DESCRIPTION
- changed to point to gitea repo